### PR TITLE
Add search path, fixes #4

### DIFF
--- a/GUI/Layers/Browser.cpp
+++ b/GUI/Layers/Browser.cpp
@@ -68,7 +68,7 @@ Browser::open(isize dfn)
  
     // Assign action function
     action = [this, dfn](const string &s) {
-        amiga.paula.diskController.insertDisk(s, dfn);
+        amiga.paula.diskController.insertDisk(amiga.paula.diskController.getSearchPath(dfn) + "/" + s, dfn);
     };
     
     // Get the media directory for this drive


### PR DESCRIPTION
When loading a disk image via File Browser, only the Filename is handed over. This leads to FILE_NOT_FOUND error message.
To fix this, the absolute path needs to be handed over.