### PR TITLE
Fix DMS files

### DIFF
--- a/Emulator/Files/AmigaFile.h
+++ b/Emulator/Files/AmigaFile.h
@@ -96,7 +96,7 @@ public:
     
     template <class T> static T *make(const string &path, std::istream &stream) throws
     {
-        if (!T::isCompatiblePath(path)) throw VAError(ERROR_FILE_TYPE_MISMATCH);
+        if (!path.empty() && !T::isCompatiblePath(path)) throw VAError(ERROR_FILE_TYPE_MISMATCH);
         if (!T::isCompatibleStream(stream)) throw VAError(ERROR_FILE_TYPE_MISMATCH);
         
         T *obj = new T();

--- a/Emulator/xdms/pfile.c
+++ b/Emulator/xdms/pfile.c
@@ -148,9 +148,6 @@ USHORT extractDMS(FILE *fi, FILE *fo) {
     /*  we suppose that the valid data is over. And say it's ok. */
     if (ret == ERR_NOTTRACK) ret = NO_PROBLEM;
     
-    fclose(fi);
-    fclose(fo);
-    
     free(b1);
     free(b2);
     free(text);


### PR DESCRIPTION
Loading a DMS file on Linux causes the following two errors:
1. free(): double free detected in tcache 2 in Emulator/Files/DiskFiles/DMSFile.cpp:56+57
    ```
    ################################################################################
    free(): double free detected in tcache 2
    Aborted (core dumped)
    ```
    Because the 2 FILE* are already closed in Emulator/xdms/pfile.c:151+152

2. VAError( INVALID_TYPE ) in Emulator/Files/AmigaFile.h:99
    On line Emulator/Files/AmigaFile.h:152 it is called with "" as path
    ```
    ################################################################################
    terminate called after throwing an instance of 'VAError'
      what():  INVALID_TYPE
    Aborted (core dumped)
    ```
In vAmiga 1.0 on MacOS these issues do not occur